### PR TITLE
fix: create box from the client

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           capture: "junit.xml"
           args: "-t --formatter JUnit"
-          extra_libs: mysql+polyzone+qblocales
+          extra_libs: mysql+polyzone+qblocales+ox_lib
       - name: Generate Lint Report
         if: always()
         uses: mikepenz/action-junit-report@v3

--- a/client.lua
+++ b/client.lua
@@ -14,7 +14,7 @@ local AnimNameSmashFront = {
     'smash_case_tray_b',
     'smash_case_necklace_skull'
 }
-local insideJewellery = false
+local insideJewelry = false
 local electricalBoxEntity
 
 local function DrawText3D(coords, text)
@@ -282,7 +282,7 @@ lib.zones.sphere({
         createElectricalBox()
         CreateThread(function()
             
-            while insideJewellery do
+            while insideJewelry do
                 for i = 1, #Config.Cabinets do
                     if Config.Cabinets[i].isOpened then
                         local RayFire = GetRayfireMapObject(Config.Cabinets[i].coords.x, Config.Cabinets[i].coords.y, Config.Cabinets[i].coords.z, 1.4, Config.Cabinets[i].rayFire)
@@ -295,7 +295,7 @@ lib.zones.sphere({
     end,
     onExit = function()
         removeElectricalBox()
-        insideJewellery = false
+        insideJewelry = false
     end,
 })
 

--- a/client.lua
+++ b/client.lua
@@ -162,7 +162,7 @@ if Config.UseTarget then
             coords = Config.Cabinets[i].coords,
             size = vec3(1.2, 1.6, 1),
             rotation = Config.Cabinets[i].heading,
-            debug = true,
+            --debug = true,
             options = {
                 {
                     icon = 'fas fa-gem',
@@ -277,7 +277,7 @@ end)
 lib.zones.sphere({
     coords = vec3(Config.Cabinets[1].coords.x, Config.Cabinets[1].coords.y, Config.Cabinets[1].coords.z),
     radius = 80,
-    debug = true,
+    --debug = true,
     onEnter = function()
         createElectricalBox()
         CreateThread(function()

--- a/client.lua
+++ b/client.lua
@@ -279,6 +279,7 @@ lib.zones.sphere({
     radius = 80,
     --debug = true,
     onEnter = function()
+        insideJewelry = true
         createElectricalBox()
         CreateThread(function()
             

--- a/client.lua
+++ b/client.lua
@@ -36,7 +36,6 @@ local function createElectricalBox()
     while not DoesEntityExist(electricalBoxEntity) do
         Wait(0)
     end
-    Wait(100)
     SetEntityHeading(electricalBoxEntity, Config.Electrical.w)
     if Config.UseTarget then
         local options = {

--- a/client.lua
+++ b/client.lua
@@ -60,7 +60,7 @@ end
 
 local function removeElectricalBox()
     if Config.UseTarget then
-        exports.ox_target:removeLocalEntity({electricalBoxEntity}, 'qb-jewelery:electricalBox')
+        exports.ox_target:removeLocalEntity(electricalBoxEntity, 'qb-jewelery:electricalBox')
     end
     if electricalBoxEntity ~= nil and DoesEntityExist(electricalBoxEntity) then
         DeleteObject(electricalBoxEntity)

--- a/locale/en.lua
+++ b/locale/en.lua
@@ -1,6 +1,7 @@
 local Translations = {
     text = {
         electrical = '~g~E~w~ - Hack Doorlock',
+        electricalTarget = 'Hack Doorlock',
         cabinet = '~g~E~w~ - Smash Cabinet'
     },
     notify = {

--- a/server.lua
+++ b/server.lua
@@ -1,5 +1,4 @@
 local QBCore = exports['qbx-core']:GetCoreObject()
-local ElectricalBoxEntity
 local ElectricalBusy
 local StartedElectrical = {}
 local StartedCabinet = {}
@@ -101,21 +100,6 @@ RegisterNetEvent('qb-jewellery:server:succeshackdoor', function()
     StartedElectrical[source] = false
     QBCore.Functions.Notify(source, 'Hack successful')
     TriggerEvent('ox_doorlock:setState', DoorEntrance.id, 0)
-end)
-
-AddEventHandler('onResourceStop', function(resource)
-    if resource ~= GetCurrentResourceName() then return end
-    if not DoesEntityExist(ElectricalBoxEntity) then return end
-    DeleteEntity(ElectricalBoxEntity)
-end)
-
-CreateThread(function()
-    Wait(250)
-    ElectricalBoxEntity = CreateObject(`tr_prop_tr_elecbox_01a`, Config.Electrical.x, Config.Electrical.y, Config.Electrical.z, true, false, false)
-    while ElectricalBoxEntity == 0 do ElectricalBoxEntity = CreateObject(`tr_prop_tr_elecbox_01a`, Config.Electrical.x, Config.Electrical.y, Config.Electrical.z, true, false, false) Wait(3000) end
-    while not DoesEntityExist(ElectricalBoxEntity) do Wait(0) end
-    Wait(100)
-    SetEntityHeading(ElectricalBoxEntity, Config.Electrical.w)
 end)
 
 AddEventHandler('playerJoining', function(source)


### PR DESCRIPTION
## Description

This addresses issue 4, now spawning the electrical box when the player is near the jewelry store. Also makes the rayfire thread only active inside that same zone.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My code fits the style guidelines.
- [X] My PR fits the contribution guidelines.
